### PR TITLE
add handle_syndicate_to_query, fix handle_undelete signature

### DIFF
--- a/lib/plug_micropub/handler_behaviour.ex
+++ b/lib/plug_micropub/handler_behaviour.ex
@@ -30,14 +30,17 @@ defmodule PlugMicropub.HandlerBehaviour do
   @callback handle_undelete(url :: String.t(), access_token) ::
               :ok
               | {:ok, url :: String.t()}
-              | {:error, handler_error}
-              | {:error, handler_error, error_description :: String.t()}
+              | handler_error
 
   @callback handle_config_query(access_token) ::
               {:ok, map}
               | handler_error
 
   @callback handle_config_query(access_token) ::
+              {:ok, map}
+              | handler_error
+
+  @callback handle_syndicate_to_query(access_token) ::
               {:ok, map}
               | handler_error
 


### PR DESCRIPTION
This adds handle_syndicate_to_query to the HandlerBehaviour.

It also changes the signature of `handle_undelete` to be uniform with the rest of the callbacks. Not sure if the signature `{:error, {:error, :insufficient_scope}}` was intended.